### PR TITLE
fix: use single quote for model template

### DIFF
--- a/lib/template.js
+++ b/lib/template.js
@@ -1,7 +1,7 @@
 var model = function (props) {
   return `// import { xxx } from '../services/xxx';
 export default {
-  namespace: "${props.name}",
+  namespace: '${props.name}',
   state: {},
   effects: {
     *fetch({ payload }, { call, put }) {


### PR DESCRIPTION
use single quote for model template, because `ant-design-pro` use single quotes '' for strings