### PR TITLE
feat: screenshot support dumi block

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,11 @@ pro -h
 
 ### screenshot
 
-- pro screenshot 
-- pro screenshot --path DashboardWorkplace
-- pro screenshot --mobile 
+- pro screenshot 对所有区块进行截图
+- pro screenshot --path DashboardWorkplace 对单个区块进行截图
+- pro screenshot --mobile 对所有区块进行截图
+- pro screenshot --dumi 使用 dumi 构建的资产，支持手机模式
+
 ### i18n-remove
 
 - pro i18n-remove --write

--- a/cli.js
+++ b/cli.js
@@ -32,9 +32,19 @@ const screenshot = async (props) => {
   process.exit(0);
 }
 
+const screenshotDumi = async (props) => {
+  // eslint-disable-next-line global-require
+  await require('./src/screenshot/dumi')(props);
+  process.exit(0);
+}
+
 switch (option) {
   case 'screenshot':
-    screenshot({ cwd, ...args });
+    if (args.dumi) {
+      screenshotDumi({ cwd, ...args });
+    } else {
+      screenshot({ cwd, ...args });
+    }
     break;
   case 'i18n-remove':
     // eslint-disable-next-line global-require

--- a/src/screenshot/dumi.js
+++ b/src/screenshot/dumi.js
@@ -1,0 +1,229 @@
+const { spawn } = require('child_process');
+const { join } = require('path');
+const fs = require('fs');
+const chalk = require('chalk');
+const PNGImage = require('pngjs-image');
+const { kill } = require('cross-port-killer');
+const ora = require('ora');
+
+const getBrowser = require('./getBrowser');
+
+const portAvailable = require('./portAvailable');
+const diffPng = require('./diff');
+
+const spinner = ora();
+
+const env = Object.create(process.env);
+env.BROWSER = 'none';
+env.PORT = process.env.PORT || '8000';
+env.TEST = true;
+env.COMPRESS = 'none';
+env.PROGRESS = 'none';
+env.BLOCK_PAGES_LAYOUT = 'blankLayout';
+
+let browser;
+
+let diffFile = [];
+
+/**
+ * 启动区块服务
+ */
+const startServer = async () => {
+  let once = false;
+  return new Promise(resolve => {
+    const server = spawn(/^win/.test(process.platform) ? 'npm.cmd' : 'npm', ['run', 'start'], {
+      env,
+    });
+    server.stdout.on('data', data => {
+      // hack code , wait umi
+      if (!once && data.toString().indexOf('Compiled successfully') >= 0) {
+        once = true;
+        resolve(server);
+      }
+    });
+    server.on('exit', () => {
+      kill(env.PORT || 8000);
+    });
+  });
+};
+
+const autoScroll = page =>
+  page.evaluate(
+    () =>
+      new Promise(resolve => {
+        let totalHeight = 0;
+        const distance = 100;
+        const timer = setInterval(() => {
+          const { scrollHeight } = document.body;
+          window.scrollBy(0, distance);
+          totalHeight += distance;
+          if (totalHeight >= scrollHeight) {
+            clearInterval(timer);
+            resolve();
+          }
+        }, 100);
+      }),
+  );
+
+const setFontFamily = page => {
+  page.evaluate(
+    () =>
+      new Promise(resolve => {
+        const link = document.createElement('style');
+        link.href = 'https://fonts.googleapis.com/css?family=Space+Mono&display=swap';
+        link.rel = 'stylesheet';
+        const style = document.createElement('style');
+        const textNode = document.createTextNode(`
+          *{
+            font-family: 'Space Mono', monospace !important; 
+          }
+        `);
+        style.appendChild(textNode);
+        link.onload = () => {
+          resolve();
+        };
+        document.head.appendChild(link);
+        document.head.appendChild(style);
+      }),
+  );
+};
+
+const readPng = path =>
+  new Promise((resolve, reject) => {
+    PNGImage.readImage(path, (error, image) => {
+      if (error) {
+        reject(error);
+      }
+      resolve(image);
+    });
+  });
+
+const screenshot = async ({ page, routesList, diff, mobile, out }) => {
+  try {
+    const isAvailable = await portAvailable(8000);
+    if (!isAvailable) {
+      kill(env.PORT || 8000);
+    }
+  } catch (error) {
+    console.log(error);
+  }
+  let outPath = out || `${process.cwd()}/screenshot/`;
+
+  if (!fs.existsSync(outPath)) {
+    spinner.start(`🐆  create outPath`);
+    await fs.mkdirSync(outPath);
+    spinner.succeed();
+  }
+  spinner.start(`🚀  start server`);
+  const server = await startServer();
+  spinner.succeed();
+  // /~demos/card-demo
+  const loopGetImage = async index => {
+    try {
+      const route = routesList[index];
+      await page.goto(`http://127.0.0.1:${env.PORT}/~demos/${route}`);
+
+      await page.setViewport({
+        width: mobile ? 375 : 1440,
+        height: mobile ? 667 : 800,
+      });
+
+      spinner.start(`💄  set style (${route})`);
+      await autoScroll(page);
+      await setFontFamily(page);
+      spinner.succeed();
+
+      const imagePath = join(outPath, `${route}.png`);
+      let png = null;
+      // if diff read file
+      if (diff) {
+        try {
+          png = await readPng(imagePath);
+        } catch (error) {
+          diff = false;
+        }
+      }
+
+      spinner.start(`📷  snapshot block image  (${route})`);
+
+      await page.screenshot({
+        path: imagePath,
+        fullPage: true,
+      });
+      spinner.succeed();
+
+      if (diff) {
+        const diffPngPath = join(outPath, `${route}-diff.png`);
+        spinner.start(`👀  diff ${imagePath}`);
+        const isDiff = await diffPng(png, imagePath, diffPngPath);
+        if (!isDiff) {
+          diffFile.push(path);
+        }
+        spinner.succeed();
+      }
+
+      if (routesList.length > index && routesList[index + 1]) {
+        return loopGetImage(index + 1);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+    return Promise.resolve(true);
+  };
+  await loopGetImage(0);
+  server.kill();
+};
+
+const openBrowser = async () => {
+  browser = await getBrowser();
+  const page = await browser.newPage();
+  return page;
+};
+
+/**
+ * 取得所有区块
+ */
+const getAllFile = async (cwd, filePath) => {
+  let assetsJson;
+  if (filePath) {
+    assetsJson = filePath;
+  } else if (fs.existsSync(join(cwd, 'assets.json'))) {
+    assetsJson = join(cwd, 'assets.json')
+  } else {
+    console.error('no find the dumi assets json.');
+    console.log('Please try to execute: dumi assets!');
+    return;
+  }
+  const data = JSON.parse(fs.readFileSync(assetsJson, 'utf-8') || '[]')
+  let examples = [];
+  if (data && data.assets && data.assets.examples) {
+    examples = data.assets.examples;
+  }
+  return (examples).map(demo => demo.identifier);
+};
+
+module.exports = async ({ cwd, diff, path, mobile, out }) => {
+  diffFile = [];
+  spinner.start('🔍  Get block');
+  const routesList = await getAllFile(cwd, path);
+  spinner.succeed();
+
+  spinner.start('🌏  Start puppeteer');
+  const page = await openBrowser();
+  spinner.succeed();
+  await screenshot({
+    page,
+    routesList,
+    diff,
+    mobile,
+    out
+  });
+
+  if (diffFile.length > 0) {
+    console.log(`End of diff, ${diffFile.length} failed.`);
+    console.log(chalk.red(diffFile.join('\n')));
+  }
+
+  browser.close();
+  return diffFile;
+};


### PR DESCRIPTION
use pro screenshot --dumi

![image](https://user-images.githubusercontent.com/11746742/129661463-817662a6-19ee-4d6e-92ec-3f626c3629ba.png)

将截图保存到 screenshot 目录下，然后通过插件，把截图数据放到 dumi 的 assets 数据中。

```
import { IApi } from 'dumi';
import IAssetsPackage from 'dumi-assets-types';

export default (api: IApi) => {
  if (!process.env.GENERATE_ASSRTS) return;

  api.register({
    key: 'dumi.modifyAssetsMeta',
    fn(pkg: IAssetsPackage) {
      // 处理 pkg 并返回新的 pkg
      pkg.assets.examples = pkg.assets.examples.map(item => ({ ...item, screenshot: `https://raw.githubusercontent.com/alitajs/antd-mobile-plus/master/screenshot/${item.identifier}.png?raw=true` }))
      return pkg;
    },
  });
};
```