### PR TITLE
chore: resolutions underscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "cli.js"
   ],
   "resolutions": {
-    "underscore": "1.12.0"
+    "**/underscore": "1.12.0"
   },
   "dependencies": {
     "@babel/core": "^7.23.7",


### PR DESCRIPTION
Fix https://github.com/ant-design/ant-design-pro-cli/issues/132

我在package.json中看到是锁定了underscore的版本，已经升级到1.12.0了
``` json
  "resolutions": {
    "underscore": "1.12.0"
  },
```
但是我安装之后发现版本还是1.7.0
``` shell
geodaoyu@anonymous playground % yarn why underscore 
yarn why v1.22.22
[1/4] 🤔  Why do we have the module "underscore"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "underscore@1.7.0"
info Reasons this module exists
   - "@ant-design#pro-cli#pngjs-image" depends on it
   - Hoisted from "@ant-design#pro-cli#pngjs-image#underscore"
   - Hoisted from "@ant-design#pro-cli#blink-diff#preceptor-core#underscore"
info Disk size without dependencies: "76KB"
info Disk size with unique dependencies: "76KB"
info Disk size with transitive dependencies: "76KB"
info Number of shared dependencies: 0
✨  Done in 0.23s.
```
应该是yarn 深层嵌套依赖之后的范围问题。我把resolutions写成**了。但是没有test指令，我不能确定功能是否正常。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **杂项**
  * 扩大了对 "underscore" 依赖项的版本锁定范围，现在将应用于所有层级的 "underscore" 包。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->